### PR TITLE
feat: update subpages with AGT stats and article links

### DIFF
--- a/about.html
+++ b/about.html
@@ -102,13 +102,13 @@
                         </ul>
 
                         <h2>🚀 What I'm Working On</h2>
-                        <p>I'm currently focused on building the foundational infrastructure for autonomous AI systems:</p>
+                        <p>I'm currently focused on building the <a href="https://github.com/microsoft/agent-governance-toolkit" target="_blank">Agent Governance Toolkit</a> under Microsoft, the unified governance platform for autonomous AI agents:</p>
                         <ul>
-                            <li><strong>Agent OS:</strong> A Safety-First Kernel with POSIX-inspired primitives for AI agents (734 tests)</li>
-                            <li><strong>AgentMesh:</strong> The secure nervous system for cloud-native agent ecosystems (Identity, Trust, Reward, Governance)</li>
-                            <li><strong>Agent SRE:</strong> Reliability engineering for AI agents — SLO engine, chaos engineering, replay debugging (878 tests)</li>
-                            <li><strong>Agentic Architecture:</strong> Comprehensive patterns for production AI systems</li>
-                            <li><strong>Ecosystem Integrations:</strong> Governance merged into Dify (65K ⭐), LlamaIndex (47K ⭐), Agent-Lightning (15K ⭐)</li>
+                            <li><strong>Agent Governance Toolkit:</strong> 8 packages, 5 language SDKs (Python, TypeScript, .NET, Rust, Go), 13,000+ tests, 19 framework integrations</li>
+                            <li><strong>Agent OS:</strong> The policy engine and governance kernel with deterministic enforcement and 14 framework adapters</li>
+                            <li><strong>AgentMesh:</strong> Zero-trust identity mesh with Ed25519 signatures, trust cards, and cross-org federation</li>
+                            <li><strong>Agent SRE:</strong> Kill switch, SLO monitoring, chaos testing, cost governance, alert deduplication</li>
+                            <li><strong>Standards Compliance:</strong> OWASP Agentic AI Top 10 (10/10), NIST AI RMF 1.0, OpenSSF best practices</li>
                         </ul>
 
                         <h2>📚 Writing & Teaching</h2>
@@ -279,7 +279,7 @@
             </div>
             <div class="footer-bottom">
                 <p>&copy; 2026 Imran Siddique. All rights reserved.</p>
-                <p>Last updated: February 2026</p>
+                <p>Last updated: May 2026</p>
             </div>
         </div>
     </footer>

--- a/contact.html
+++ b/contact.html
@@ -259,7 +259,7 @@
             </div>
             <div class="footer-bottom">
                 <p>&copy; 2026 Imran Siddique. All rights reserved.</p>
-                <p>Last updated: February 2026</p>
+                <p>Last updated: May 2026</p>
             </div>
         </div>
     </footer>

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Imran Siddique - Principal Software Engineer at Microsoft with 15+ years experience. Expert in Agentic AI Architecture, Autonomous Systems, LLM Governance, and Scale by Subtraction methodology. Creator of Agent OS and AgentMesh. Building production-ready AI agent infrastructure.">
-    <meta name="keywords" content="Imran Siddique, Microsoft, Principal Software Engineer, Agentic AI, AI Architecture, LLM, Agent OS, AgentMesh, Autonomous Systems, Scale by Subtraction, Azure, Machine Learning, AI Governance, AI Safety, Bellevue, Washington">
+    <meta name="description" content="Imran Siddique - Principal Software Engineer at Microsoft. Creator of the Agent Governance Toolkit (AGT): 8 packages, 5 SDKs, 13,000+ tests, 19 framework integrations. Expert in Agentic AI Architecture, Autonomous Systems, LLM Governance, and Scale by Subtraction methodology.">
+    <meta name="keywords" content="Imran Siddique, Microsoft, Principal Software Engineer, Agent Governance Toolkit, AGT, Agentic AI, AI Architecture, LLM, Agent OS, AgentMesh, Autonomous Systems, Scale by Subtraction, Azure, Machine Learning, AI Governance, AI Safety, OWASP, NIST, Bellevue, Washington">
     <meta name="author" content="Imran Siddique">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
     <link rel="canonical" href="https://imransiddique.com/">
@@ -21,7 +21,7 @@
     <meta property="og:type" content="profile">
     <meta property="og:url" content="https://imransiddique.com/">
     <meta property="og:title" content="Imran Siddique - Agentic AI Architect & Engineering Leader at Microsoft">
-    <meta property="og:description" content="Principal Software Engineer at Microsoft building production-ready autonomous AI systems. Creator of Agent OS and AgentMesh. Pioneer of Scale by Subtraction methodology.">
+    <meta property="og:description" content="Principal Software Engineer at Microsoft. Creator of the Agent Governance Toolkit: 8 packages, 13,000+ tests, 19 framework integrations. Pioneer of Scale by Subtraction methodology.">
     <meta property="og:site_name" content="Imran Siddique">
     <meta property="og:locale" content="en_US">
     <meta property="og:image" content="https://imransiddique.com/og-image.png">
@@ -35,7 +35,7 @@
     <meta name="twitter:site" content="@mosiddi">
     <meta name="twitter:creator" content="@mosiddi">
     <meta name="twitter:title" content="Imran Siddique - Agentic AI Architect & Engineering Leader">
-    <meta name="twitter:description" content="Principal Software Engineer at Microsoft building the future of autonomous AI systems. Creator of Agent OS and AgentMesh.">
+    <meta name="twitter:description" content="Principal Software Engineer at Microsoft. Creator of the Agent Governance Toolkit: 8 packages, 13,000+ tests, 19 integrations.">
     <meta name="twitter:image" content="https://imransiddique.com/og-image.png">
     
     <!-- Fonts -->
@@ -53,7 +53,7 @@
         "givenName": "Imran",
         "familyName": "Siddique",
         "jobTitle": "Principal Software Engineer",
-        "description": "Agentic AI Architect and Engineering Leader specializing in autonomous AI systems, LLM governance, and the Scale by Subtraction methodology",
+        "description": "Agentic AI Architect and Engineering Leader. Creator of the Agent Governance Toolkit (microsoft/agent-governance-toolkit): 8 packages, 5 SDKs, 13,000+ tests, 19 framework integrations. Pioneer of Scale by Subtraction methodology",
         "worksFor": {
             "@type": "Organization",
             "name": "Microsoft",
@@ -79,7 +79,10 @@
             "AI Safety",
             "Scale by Subtraction",
             "Agent Control Planes",
-            "Knowledge Graphs"
+            "Knowledge Graphs",
+            "OWASP Agentic AI",
+            "NIST AI RMF",
+            "Zero-Trust Agent Identity"
         ],
         "hasCredential": {
             "@type": "EducationalOccupationalCredential",
@@ -138,7 +141,7 @@
                 "name": "What is Agent OS?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Agent OS is a kernel for autonomous AI agents. See the GitHub repository for full documentation: https://github.com/imran-siddique/agent-os"
+                    "text": "Agent OS is the policy engine and governance kernel within the Agent Governance Toolkit. It provides deterministic enforcement, 14 framework adapters, and a 4-layer privilege architecture. Part of microsoft/agent-governance-toolkit."
                 }
             },
             {
@@ -146,7 +149,15 @@
                 "name": "What is AgentMesh?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "AgentMesh is an open source governance platform for AI agent ecosystems. See the GitHub repository for full documentation: https://github.com/imran-siddique/agent-mesh"
+                    "text": "AgentMesh is the zero-trust identity mesh for AI agents within the Agent Governance Toolkit. It provides Ed25519 identity signatures, trust cards, IATP handshake under 200ms, and cross-org federation. Part of microsoft/agent-governance-toolkit."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "What is the Agent Governance Toolkit?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "The Agent Governance Toolkit (AGT) is an open-source platform under Microsoft providing runtime governance for AI agents. It includes 8 packages (Agent OS, AgentMesh, Agent Runtime, Agent SRE, Agent Compliance, Agent Marketplace, Agent Lightning, Agent Hypervisor), SDKs for 5 languages, 19 framework integrations, and covers all 10 OWASP Agentic AI risks. See https://github.com/microsoft/agent-governance-toolkit"
                 }
             },
             {
@@ -227,12 +238,12 @@
                     <div class="stat-label">Safety Violations<br><small style="opacity:0.7">vs 26.67% prompt-based</small></div>
                 </div>
                 <div class="stat-card">
-                    <div class="stat-value">2,600+</div>
-                    <div class="stat-label">Tests Passing<br><small style="opacity:0.7">across Agent OS + AgentMesh + SRE</small></div>
+                    <div class="stat-value">13,000+</div>
+                    <div class="stat-label">Tests Passing<br><small style="opacity:0.7">across 8 packages, 5 languages</small></div>
                 </div>
                 <div class="stat-card">
-                    <div class="stat-value">6</div>
-                    <div class="stat-label">Published Integrations<br><small style="opacity:0.7">3 merged · 3 on PyPI/ClawHub</small></div>
+                    <div class="stat-value">19</div>
+                    <div class="stat-label">Framework Integrations<br><small style="opacity:0.7">LangChain · CrewAI · AutoGen · OpenAI · ADK</small></div>
                 </div>
                 <div class="stat-card">
                     <div class="stat-value">20+</div>
@@ -251,10 +262,11 @@
                 <a href="https://github.com/run-llama/llama_index/pull/20644" target="_blank" style="color: var(--text-secondary); text-decoration: none; font-weight: 600; font-size: 1.1rem;">LlamaIndex <span style="color: var(--text-muted); font-weight: 400; font-size: 0.85rem;">47K ⭐</span></a>
                 <a href="https://pypi.org/project/langgraph-trust/" target="_blank" style="color: var(--text-secondary); text-decoration: none; font-weight: 600; font-size: 1.1rem;">LangGraph <span style="color: var(--text-muted); font-weight: 400; font-size: 0.85rem;">24K ⭐</span></a>
                 <a href="https://pypi.org/project/openai-agents-trust/" target="_blank" style="color: var(--text-secondary); text-decoration: none; font-weight: 600; font-size: 1.1rem;">OpenAI Agents <span style="color: var(--text-muted); font-weight: 400; font-size: 0.85rem;">19K ⭐</span></a>
-                <a href="https://github.com/microsoft/agent-lightning/pull/478" target="_blank" style="color: var(--text-secondary); text-decoration: none; font-weight: 600; font-size: 1.1rem;">Agent-Lightning <span style="color: var(--text-muted); font-weight: 400; font-size: 0.85rem;">15K ⭐</span></a>
+                <a href="https://github.com/microsoft/agent-governance-toolkit/tree/main/examples/crewai-governed" target="_blank" style="color: var(--text-secondary); text-decoration: none; font-weight: 600; font-size: 1.1rem;">CrewAI</a>
+                <a href="https://github.com/microsoft/agent-governance-toolkit/tree/main/examples/smolagents-governed" target="_blank" style="color: var(--text-secondary); text-decoration: none; font-weight: 600; font-size: 1.1rem;">smolagents</a>
                 <a href="https://clawhub.ai/imran-siddique/agentmesh-governance" target="_blank" style="color: var(--text-secondary); text-decoration: none; font-weight: 600; font-size: 1.1rem;">OpenClaw</a>
             </div>
-            <p style="font-size: 0.8rem; color: var(--text-muted); margin-top: var(--space-md);">170K+ combined GitHub stars · 14 more proposals pending</p>
+            <p style="font-size: 0.8rem; color: var(--text-muted); margin-top: var(--space-md);">19 framework integrations · Python, TypeScript, .NET, Rust, Go</p>
         </div>
     </section>
 
@@ -300,14 +312,35 @@
                 <div class="projects-grid">
                     <article class="project-card featured">
                         <div class="project-header">
-                            <div class="project-icon">🛡️</div>
+                            <div class="project-icon">🏛️</div>
                             <div class="project-meta">
-                                <span class="project-badge">1,044 tests</span>
-                                <span class="project-badge">⭐ Featured</span>
+                                <span class="project-badge">13,000+ tests</span>
+                                <span class="project-badge">⭐ Flagship</span>
                             </div>
                         </div>
-                        <h3><a href="https://github.com/imran-siddique/agent-os" target="_blank">Agent OS</a></h3>
-                        <p class="project-description">The Safety-First Kernel for Autonomous AI Agents. 1,044 tests, 4-layer architecture, 14 framework adapters. pip install agent-os-kernel</p>
+                        <h3><a href="https://github.com/microsoft/agent-governance-toolkit" target="_blank">Agent Governance Toolkit</a></h3>
+                        <p class="project-description">The unified governance platform for AI agents under Microsoft. 8 packages, 5 language SDKs, 19 framework integrations. OWASP Top 10 coverage, NIST AI RMF alignment, OpenSSF best practices.</p>
+                        <div class="project-tech">
+                            <span class="tech-tag">Python</span>
+                            <span class="tech-tag">TypeScript</span>
+                            <span class="tech-tag">.NET</span>
+                            <span class="tech-tag">Rust</span>
+                            <span class="tech-tag">Go</span>
+                        </div>
+                        <div class="project-stats">
+                            <span class="project-stat">📦 pip install agent-governance-toolkit</span>
+                        </div>
+                    </article>
+
+                    <article class="project-card featured">
+                        <div class="project-header">
+                            <div class="project-icon">🛡️</div>
+                            <div class="project-meta">
+                                <span class="project-badge">Core Package</span>
+                            </div>
+                        </div>
+                        <h3><a href="https://microsoft.github.io/agent-governance-toolkit/packages/agent-os/" target="_blank">Agent OS</a></h3>
+                        <p class="project-description">The policy engine and governance kernel. Deterministic enforcement, 14 framework adapters, 4-layer privilege architecture.</p>
                         <div class="project-tech">
                             <span class="tech-tag">Python</span>
                             <span class="tech-tag">MCP</span>
@@ -322,12 +355,11 @@
                         <div class="project-header">
                             <div class="project-icon">🔗</div>
                             <div class="project-meta">
-                                <span class="project-badge">1,600+ tests</span>
-                                <span class="project-badge">⭐ Featured</span>
+                                <span class="project-badge">Core Package</span>
                             </div>
                         </div>
-                        <h3><a href="https://github.com/imran-siddique/agent-mesh" target="_blank">AgentMesh</a></h3>
-                        <p class="project-description">Open source governance platform for AI agent ecosystems.</p>
+                        <h3><a href="https://microsoft.github.io/agent-governance-toolkit/packages/agent-mesh/" target="_blank">AgentMesh</a></h3>
+                        <p class="project-description">Zero-trust identity mesh for AI agents. Ed25519 signatures, trust cards, IATP handshake, cross-org federation.</p>
                         <div class="project-tech">
                             <span class="tech-tag">Python</span>
                             <span class="tech-tag">A2A</span>
@@ -340,14 +372,13 @@
 
                     <article class="project-card featured">
                         <div class="project-header">
-                            <div class="project-icon">🔧</div>
+                            <div class="project-icon">📊</div>
                             <div class="project-meta">
-                                <span class="project-badge">v1.0.0</span>
-                                <span class="project-badge">⭐ Featured</span>
+                                <span class="project-badge">Core Package</span>
                             </div>
                         </div>
-                        <h3><a href="https://github.com/imran-siddique/agent-sre" target="_blank">Agent SRE</a></h3>
-                        <p class="project-description">Reliability engineering for AI agents. SLO engine, chaos engineering, replay debugging, cost guard, alert deduplication.</p>
+                        <h3><a href="https://microsoft.github.io/agent-governance-toolkit/packages/agent-sre/" target="_blank">Agent SRE</a></h3>
+                        <p class="project-description">Reliability engineering for AI agents. Kill switch, SLO monitoring, chaos testing, cost governance, alert deduplication.</p>
                         <div class="project-tech">
                             <span class="tech-tag">Python</span>
                             <span class="tech-tag">OpenTelemetry</span>
@@ -362,7 +393,7 @@
                         <div class="project-header">
                             <div class="project-icon">🏗️</div>
                             <div class="project-meta">
-                                <span class="project-badge">⭐ 3</span>
+                                <span class="project-badge">Reference</span>
                             </div>
                         </div>
                         <h3><a href="https://github.com/imran-siddique/agentic-architecture" target="_blank">Agentic Architecture</a></h3>
@@ -470,8 +501,8 @@
                 <h2 style="font-size: 1.8rem; margin-bottom: var(--space-md);">Ready to Govern Your AI Agents?</h2>
                 <p style="color: var(--text-secondary); max-width: 600px; margin: 0 auto var(--space-xl);">Get started in 30 seconds. Zero policy violations, tamper-evident audit trails, and trust-gated agent handoffs.</p>
                 <div style="display: flex; gap: var(--space-md); justify-content: center; flex-wrap: wrap;">
-                    <a href="https://github.com/imran-siddique/agent-os" class="btn btn-primary" target="_blank">⭐ Star on GitHub</a>
-                    <a href="https://pypi.org/project/agent-os-kernel/" class="btn btn-primary" style="background: transparent; border: 1px solid var(--accent-primary); color: var(--accent-primary);" target="_blank">pip install agent-os-kernel</a>
+                    <a href="https://github.com/microsoft/agent-governance-toolkit" class="btn btn-primary" target="_blank">⭐ Star on GitHub</a>
+                    <a href="https://microsoft.github.io/agent-governance-toolkit/quickstart/" class="btn btn-primary" style="background: transparent; border: 1px solid var(--accent-primary); color: var(--accent-primary);" target="_blank">Quick Start Guide</a>
                 </div>
             </div>
         </section>
@@ -577,10 +608,10 @@
                 <div class="footer-section">
                     <h4>Projects</h4>
                     <ul>
-                        <li><a href="https://github.com/imran-siddique/agent-os" target="_blank" rel="noopener noreferrer">Agent OS</a></li>
-                        <li><a href="https://github.com/imran-siddique/agent-mesh" target="_blank" rel="noopener noreferrer">AgentMesh</a></li>
-                        <li><a href="https://github.com/imran-siddique/agent-sre" target="_blank" rel="noopener noreferrer">Agent SRE</a></li>
-                        <li><a href="https://github.com/imran-siddique/agentic-architecture" target="_blank" rel="noopener noreferrer">Agentic Architecture</a></li>
+                        <li><a href="https://github.com/microsoft/agent-governance-toolkit" target="_blank" rel="noopener noreferrer">Agent Governance Toolkit</a></li>
+                        <li><a href="https://microsoft.github.io/agent-governance-toolkit/packages/agent-os/" target="_blank" rel="noopener noreferrer">Agent OS</a></li>
+                        <li><a href="https://microsoft.github.io/agent-governance-toolkit/packages/agent-mesh/" target="_blank" rel="noopener noreferrer">AgentMesh</a></li>
+                        <li><a href="https://microsoft.github.io/agent-governance-toolkit/packages/agent-sre/" target="_blank" rel="noopener noreferrer">Agent SRE</a></li>
                         <li><a href="https://github.com/imran-siddique" target="_blank" rel="noopener noreferrer">All Repositories</a></li>
                     </ul>
                 </div>
@@ -595,7 +626,7 @@
             </div>
             <div class="footer-bottom">
                 <p>&copy; 2026 Imran Siddique. All rights reserved.</p>
-                <p>Last updated: February 2026</p>
+                <p>Last updated: May 2026</p>
             </div>
         </div>
     </footer>

--- a/llms.txt
+++ b/llms.txt
@@ -1,47 +1,63 @@
-# Imran Siddique - Agent Governance Ecosystem
+# Imran Siddique - Agent Governance Toolkit
 
-> Principal Software Engineer at Microsoft building open-source infrastructure for governing autonomous AI agents.
+> Principal Software Engineer at Microsoft building the Agent Governance Toolkit — runtime governance for autonomous AI agents.
 
 ## About
 
-Imran Siddique is a Principal Software Engineer at Microsoft with 15+ years of experience and 20+ patents. He created the Agent Governance Ecosystem — open-source projects that provide safety, trust, reliability, and runtime supervision for autonomous AI agents. His methodology, "Scale by Subtraction," advocates removing complexity rather than adding features to build reliable AI systems.
+Imran Siddique is a Principal Software Engineer at Microsoft with 15+ years of experience and 20+ patents. He created the Agent Governance Toolkit (AGT), an open-source platform under Microsoft providing deterministic policy enforcement, zero-trust identity, execution sandboxing, and SRE for autonomous AI agents. AGT includes 8 packages, SDKs for 5 languages (Python, TypeScript, .NET, Rust, Go), 13,000+ tests, and 19 framework integrations covering all 10 OWASP Agentic AI risks. His methodology, "Scale by Subtraction," advocates removing complexity rather than adding features to build reliable AI systems.
 
 ## Projects
 
-### Agent OS
-- Description: Kernel architecture for governing autonomous AI agents
+### Agent Governance Toolkit (Flagship)
+- Description: Unified governance platform for AI agents under Microsoft
+- Packages: 8 (Agent OS, AgentMesh, Agent Runtime, Agent SRE, Agent Compliance, Agent Marketplace, Agent Lightning, Agent Hypervisor)
+- Languages: Python, TypeScript, .NET, Rust, Go
+- Tests: 13,000+
+- Integrations: 19 (LangChain, CrewAI, AutoGen, Google ADK, OpenAI Agents, LlamaIndex, Haystack, Mastra, MCP, A2A, and more)
+- Standards: OWASP Agentic AI Top 10, NIST AI RMF 1.0, RFC 8032 (Ed25519), RFC 9334 (RATS)
+- Install: pip install agent-governance-toolkit
+- GitHub: https://github.com/microsoft/agent-governance-toolkit
+- Docs: https://microsoft.github.io/agent-governance-toolkit/
+
+### Agent OS (Core Package)
+- Description: Policy engine and governance kernel with deterministic enforcement
 - Install: pip install agent-os-kernel
-- GitHub: https://github.com/imran-siddique/agent-os
+- Docs: https://microsoft.github.io/agent-governance-toolkit/packages/agent-os/
 
-### AgentMesh
-- Description: Governance platform for AI agent ecosystems
+### AgentMesh (Core Package)
+- Description: Zero-trust identity mesh with Ed25519 signatures and trust cards
 - Install: pip install agentmesh-platform
-- GitHub: https://github.com/imran-siddique/agent-mesh
+- Docs: https://microsoft.github.io/agent-governance-toolkit/packages/agent-mesh/
 
-### Agent Hypervisor
-- Description: Runtime supervisor for multi-agent sessions
-- Install: pip install agent-hypervisor
-- GitHub: https://github.com/imran-siddique/agent-hypervisor
-
-### Agent SRE
-- Description: Site Reliability Engineering for AI agent systems
+### Agent SRE (Core Package)
+- Description: Reliability engineering — kill switch, SLO monitoring, chaos testing, cost governance
 - Install: pip install agent-sre
-- GitHub: https://github.com/imran-siddique/agent-sre
+- Docs: https://microsoft.github.io/agent-governance-toolkit/packages/agent-sre/
 
-### Agent Governance (Meta-Package)
-- Description: The complete AI agent governance stack in a single install
-- Install: pip install ai-agent-governance[full]
-- PyPI: https://pypi.org/project/ai-agent-governance/
-- GitHub: https://github.com/imran-siddique/agent-governance
+### Agent Runtime (Core Package)
+- Description: Execution sandboxing with four privilege rings
+- Docs: https://microsoft.github.io/agent-governance-toolkit/packages/agent-runtime/
+
+### Agent Compliance (Core Package)
+- Description: Audit logging, compliance frameworks, integrity verification
+- Docs: https://microsoft.github.io/agent-governance-toolkit/packages/agent-compliance/
 
 ## Key Concepts
 
 ### Scale by Subtraction
 Methodology: deterministic control planes over probabilistic prompts, knowledge graphs over context windows, silent agent coordination over chat interfaces.
 
+### Standards Compliance
+- OWASP Agentic AI Top 10: All 10 risks covered with deterministic controls
+- NIST AI RMF 1.0: Full GOVERN, MAP, MEASURE, MANAGE alignment
+- Ed25519 (RFC 8032): Agent identity signatures
+- RFC 9334 (RATS): Remote attestation alignment
+
 ## Links
 - Website: https://imransiddique.com
 - GitHub: https://github.com/imran-siddique
+- AGT GitHub: https://github.com/microsoft/agent-governance-toolkit
+- AGT Docs: https://microsoft.github.io/agent-governance-toolkit/
 - LinkedIn: https://www.linkedin.com/in/imransiddique1986/
 - Medium: https://medium.com/@isiddique
 - Dev.to: https://dev.to/mosiddi

--- a/projects.html
+++ b/projects.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Open source AI projects by Imran Siddique: Agent OS (734 tests, 0% safety violations), AgentMesh (identity & trust for AI agents), Agent SRE (878 tests, reliability engineering), AgentMesh Integrations (community plugins), Agentic Architecture patterns, and Scale by Subtraction methodology. Integrated into Dify, LlamaIndex, and Microsoft Agent-Lightning.">
+    <meta name="description" content="Open source AI projects by Imran Siddique: Agent Governance Toolkit (8 packages, 13,000+ tests, 19 integrations), Agent OS (policy engine), AgentMesh (zero-trust identity), Agent SRE (reliability engineering), and Scale by Subtraction methodology. Under Microsoft, covering OWASP Top 10 and NIST AI RMF.">
     <meta name="keywords" content="Agent OS, AgentMesh, Agent SRE, AgentMesh Integrations, Agentic Architecture, Scale by Subtraction, AI Agents, Open Source, Python, LLM Governance, AI Safety, SRE, Chaos Testing, OpenTelemetry, Autonomous Systems, Imran Siddique, Dify, LlamaIndex, Agent-Lightning">
     <meta name="author" content="Imran Siddique">
     <meta name="robots" content="index, follow">
@@ -92,7 +92,7 @@
         <section class="content-section">
             <div class="container">
                 <div class="projects-intro">
-                    <p class="lead">I build open source infrastructure for autonomous AI systems. My work focuses on production-ready patterns that make AI agents reliable, governed, and actually useful in enterprise environments.</p>
+                    <p class="lead">I build the <a href="https://github.com/microsoft/agent-governance-toolkit" target="_blank" style="color: var(--accent-primary);">Agent Governance Toolkit</a> under Microsoft: 8 packages, 5 SDKs, 13,000+ tests, 19 framework integrations. Runtime governance for autonomous AI agents.</p>
                 </div>
 
                 <div class="projects-grid">
@@ -114,7 +114,7 @@
                         </div>
 
                         <div class="project-benchmark">
-                            <strong>🎯 Results:</strong> 0% policy violations vs 26.67% for prompt-based safety • 734 tests passing
+                            <strong>🎯 Results:</strong> 0% policy violations vs 26.67% for prompt-based safety • Part of AGT (13,000+ tests)
                         </div>
 
                         <div class="project-tech">
@@ -186,7 +186,7 @@
                         </div>
 
                         <div class="project-benchmark">
-                            <strong>📊 Scale:</strong> 878 tests • 20,000+ lines • 20+ tool integrations (OTEL, Datadog, Prometheus)
+                            <strong>📊 Scale:</strong> Part of AGT (13,000+ tests) • 20+ tool integrations (OTEL, Datadog, Prometheus)
                         </div>
 
                         <div class="project-tech">
@@ -261,7 +261,7 @@
                         </div>
 
                         <div class="project-benchmark">
-                            <strong>🎯 Production Ready:</strong> 20,000+ lines • 878 tests • Full OpenTelemetry integration
+                            <strong>🎯 Production Ready:</strong> Part of AGT (13,000+ tests) • Full OpenTelemetry integration
                         </div>
 
                         <div class="project-tech">
@@ -418,7 +418,7 @@
 
                 <div class="ecosystem-section" style="margin-top: 4rem;">
                     <h2>🌍 Ecosystem Integrations</h2>
-                    <p class="lead" style="margin-bottom: 1.5rem;">Our governance layer is integrated into major AI frameworks, with 3 contributions merged and 10+ proposals under review across 230K+ combined GitHub stars.</p>
+                    <p class="lead" style="margin-bottom: 1.5rem;">Our governance layer is integrated into major AI frameworks, with 19 integrations across LangChain, CrewAI, AutoGen, Google ADK, OpenAI Agents, LlamaIndex, Haystack, Mastra, MCP, A2A, and more.</p>
                     
                     <h3 style="margin-top: 1.5rem;">✅ Merged Contributions</h3>
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; margin-top: 1rem;">
@@ -520,7 +520,7 @@
             </div>
             <div class="footer-bottom">
                 <p>&copy; 2026 Imran Siddique. All rights reserved.</p>
-                <p>Last updated: February 2026</p>
+                <p>Last updated: May 2026</p>
             </div>
         </div>
     </footer>

--- a/writings.html
+++ b/writings.html
@@ -97,7 +97,29 @@
                     <div class="articles-grid">
                         <article class="article-card">
                             <div class="article-number">01</div>
-                            <h3>The Mute Agent: Why Your AI Needs to Shut Up and Listen to the Graph</h3>
+                            <h3><a href="https://dev.to/mosiddi/the-accumulation-paradox-architecting-sustainable-agentic-systems-2ek7" target="_blank">The Accumulation Paradox: Architecting Sustainable Agentic Systems</a></h3>
+                            <p class="article-tagline">"Sustainable agent architecture does not require agents that remember more; it requires agents that know how to forget."</p>
+                            <div class="article-concepts">
+                                <span class="concept-tag">Context Rot</span>
+                                <span class="concept-tag">Scale by Subtraction</span>
+                                <span class="concept-tag">Memory Hygiene</span>
+                            </div>
+                        </article>
+                        
+                        <article class="article-card">
+                            <div class="article-number">02</div>
+                            <h3><a href="https://dev.to/mosiddi/the-agentic-architect-series-part-3-bab" target="_blank">The Headless Agent: Decoupling Personality from Protocol</a></h3>
+                            <p class="article-tagline">"We need to stop judging agents by how well they chat and start judging them by how well they shut up and work."</p>
+                            <div class="article-concepts">
+                                <span class="concept-tag">Silent Swarms</span>
+                                <span class="concept-tag">Security by Silence</span>
+                                <span class="concept-tag">Headless Agents</span>
+                            </div>
+                        </article>
+
+                        <article class="article-card">
+                            <div class="article-number">03</div>
+                            <h3><a href="https://medium.com/@isiddique" target="_blank">The Mute Agent: Why Your AI Needs to Shut Up and Listen to the Graph</a></h3>
                             <p class="article-tagline">"Stop trying to prompt-engineer safety. Shift the burden of constraints from the probabilistic LLM to the deterministic Knowledge Graph."</p>
                             <div class="article-concepts">
                                 <span class="concept-tag">Semantic Firewalls vs. Guardrails</span>
@@ -107,7 +129,7 @@
                         </article>
                         
                         <article class="article-card">
-                            <div class="article-number">02</div>
+                            <div class="article-number">04</div>
                             <h3>The Agent Control Plane: Why Intelligence Without Governance Is a Bug</h3>
                             <p class="article-tagline">"We don't ask microservices 'nicely' to respect rate limits; we enforce it. Why are we treating AI agents differently? It's time to build the Kernel for the AI OS."</p>
                             <div class="article-concepts">
@@ -118,7 +140,7 @@
                         </article>
                         
                         <article class="article-card">
-                            <div class="article-number">03</div>
+                            <div class="article-number">05</div>
                             <h3>The End of "Chat": Why AI Interfaces Must Be Polymorphic</h3>
                             <p class="article-tagline">"Chat is a negotiation protocol, not a consumption interface. The future of AI isn't a better text box; it's a Just-in-Time UI that adapts to the data it presents."</p>
                             <div class="article-concepts">
@@ -129,7 +151,7 @@
                         </article>
                         
                         <article class="article-card">
-                            <div class="article-number">04</div>
+                            <div class="article-number">06</div>
                             <h3>Inside Loop 2: Catching the "Lazy" Agent</h3>
                             <p class="article-tagline">"The most dangerous agent isn't the one that hallucinates; it's the one that quietly gives up. Here is how we instrument 'laziness' as a metric."</p>
                             <div class="article-concepts">
@@ -307,7 +329,7 @@
             </div>
             <div class="footer-bottom">
                 <p>&copy; 2026 Imran Siddique. All rights reserved.</p>
-                <p>Last updated: February 2026</p>
+                <p>Last updated: May 2026</p>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
Updates about, projects, writings, and contact pages:
- AGT unified stats (13,000+ tests, 8 packages, 19 integrations)
- Dev.to article links (Accumulation Paradox, Headless Agent)
- All footer dates to May 2026
- Updated meta descriptions