### PR TITLE
content: re-center on current work (Opaque/agentrust-io) and correct all facts

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="About Imran Siddique - Chief Platform Officer at Opaque Systems, previously 18 years at Microsoft. 18+ years across distributed systems, cloud computing, and AI/ML. Expert in Agentic AI Architecture, Azure DevOps, and Scale by Subtraction methodology. Holder of 20+ patents in data platforms, sustainability, and AI systems.">
+    <meta name="description" content="About Imran Siddique - Chief Platform Officer at Opaque Systems, previously 18 years at Microsoft. 18+ years across distributed systems, cloud computing, and AI/ML. Expert in Agentic AI Architecture, Azure DevOps, and Scale by Subtraction methodology. Holder of granted and published patents in data platforms, sustainability, and AI systems.">
     <meta name="keywords" content="Imran Siddique, Opaque Systems, Chief Platform Officer, CPO, Microsoft, About, Career, Experience, Azure, AI Architecture, Distributed Systems, Engineering Leader, Scale by Subtraction, Bellevue Washington, Patents, GHG Emissions, Energy Data Platform">
     <meta name="author" content="Imran Siddique">
     <meta name="robots" content="index, follow">
@@ -103,14 +103,14 @@
                         </ul>
 
                         <h2>🚀 What I'm Working On</h2>
-                        <p>I'm currently focused on building the <a href="https://github.com/microsoft/agent-governance-toolkit" target="_blank">Agent Governance Toolkit</a> under Microsoft, the unified governance platform for autonomous AI agents:</p>
+                        <p>As Chief Platform Officer at <a href="https://www.opaque.co" target="_blank">Opaque Systems</a>, the confidential AI company, I lead platform strategy for running autonomous agents on sensitive data with verifiable trust. Alongside that I build open standards through <a href="https://agentrust-io.com" target="_blank">agentrust-io</a>:</p>
                         <ul>
-                            <li><strong>Agent Governance Toolkit:</strong> 8 packages, 5 language SDKs (Python, TypeScript, .NET, Rust, Go), 13,000+ tests, 19 framework integrations</li>
-                            <li><strong>Agent OS:</strong> The policy engine and governance kernel with deterministic enforcement and 14 framework adapters</li>
-                            <li><strong>AgentMesh:</strong> Zero-trust identity mesh with Ed25519 signatures, trust cards, and cross-org federation</li>
-                            <li><strong>Agent SRE:</strong> Kill switch, SLO monitoring, chaos testing, cost governance, alert deduplication</li>
-                            <li><strong>Standards Compliance:</strong> OWASP Agentic AI Top 10 (10/10), NIST AI RMF 1.0, OpenSSF best practices</li>
+                            <li><strong>TRACE:</strong> Trust Runtime Attestation and Compliance Evidence, an open standard for hardware-attested trust records a verifier can check without trusting the operator</li>
+                            <li><strong>cMCP:</strong> A Confidential MCP gateway that enforces tool-call policy inside a hardware TEE and emits a signed proof per session</li>
+                            <li><strong>Agent Manifest:</strong> A cryptographic identity and provenance standard that hardware-anchors the artifacts defining an agent at deployment</li>
+                            <li><strong>cA2A:</strong> Confidential agent-to-agent, attested delegation and sealed peer channels as a profile on A2A</li>
                         </ul>
+                        <p>Earlier I created the <a href="https://github.com/microsoft/agent-governance-toolkit" target="_blank">Agent Governance Toolkit</a> (hosted under Microsoft): 5 top-level distributions, 5 language SDKs, 992 conformance tests, and 10/10 OWASP Agentic Top 10 coverage. Its Agent OS, AgentMesh, and Agent SRE precursors have since been consolidated into the toolkit.</p>
 
                         <h2>📚 Writing & Teaching</h2>
                         <p>I'm passionate about sharing knowledge and challenging conventional thinking. I write extensively about agentic architecture through:</p>
@@ -123,7 +123,7 @@
                         <p>I'm also working on a book about large-scale systems development, focusing on the art of "subtraction"—removing unnecessary complexity to improve reliability.</p>
 
                         <h2>🎓 Background & Expertise</h2>
-                        <p>With more than 15 years in the industry, I've:</p>
+                        <p>With more than 18 years in the industry, I've:</p>
                         <ul>
                             <li>Led engineering teams building distributed systems at scale</li>
                             <li>Architected cloud computing and AI/ML platforms at Microsoft</li>
@@ -133,7 +133,7 @@
                         </ul>
 
                         <h2>📜 Patents</h2>
-                        <p>I hold <strong style="color: var(--accent-primary);">20+ patents</strong> at Microsoft spanning data platforms, sustainability, and AI systems:</p>
+                        <p>I hold <strong style="color: var(--accent-primary);">granted and published patents</strong> at Microsoft spanning data platforms, sustainability, and AI systems:</p>
                         
                         <div class="patents-section">
                             <h4>🌱 Sustainability & GHG Tracking</h4>
@@ -166,7 +166,7 @@
                             <h4>💼 Professional</h4>
                             <p><strong>Current Role:</strong><br>Chief Platform Officer<br>Opaque Systems</p>
                             <p><strong>Location:</strong><br>Bellevue, Washington</p>
-                            <p><strong>Experience:</strong><br>15+ years in software engineering</p>
+                            <p><strong>Experience:</strong><br>18+ years in software engineering</p>
                             <p><strong>Specialties:</strong></p>
                             <ul>
                                 <li>Agentic Architecture</li>
@@ -180,10 +180,9 @@
                         <div class="sidebar-card">
                             <h4>🏆 Achievements</h4>
                             <ul>
-                                <li>20+ Patents (Microsoft)</li>
-                                <li>1,600+ Tests Across Projects</li>
-                                <li>3 Upstream Merges (Dify, LlamaIndex, Agent-Lightning)</li>
-                                <li>11 Research Papers</li>
+                                <li>Creator of the Agent Governance Toolkit (4,877★)</li>
+                                <li>Founder of agentrust-io open standards</li>
+                                <li>Patents at Microsoft (9 listed below)</li>
                                 <li>Multiple Hackathon Wins (2021-2025)</li>
                             </ul>
                         </div>

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Imran Siddique - Chief Platform Officer at Opaque Systems, previously 18 years at Microsoft. Creator of the Agent Governance Toolkit (AGT): 8 packages, 5 SDKs, 13,000+ tests, 19 framework integrations. Expert in Agentic AI Architecture, Autonomous Systems, LLM Governance, and Scale by Subtraction methodology.">
-    <meta name="keywords" content="Imran Siddique, Opaque Systems, Chief Platform Officer, CPO, Microsoft, Agent Governance Toolkit, AGT, Agentic AI, AI Architecture, LLM, Agent OS, AgentMesh, Autonomous Systems, Scale by Subtraction, Azure, Machine Learning, AI Governance, AI Safety, OWASP, NIST, Bellevue, Washington">
+    <meta name="description" content="Imran Siddique - Chief Platform Officer at Opaque Systems, previously 18 years at Microsoft. Creator of the Agent Governance Toolkit (microsoft/agent-governance-toolkit): MIT, 992 conformance tests, 5 language SDKs, 10/10 OWASP Agentic Top 10. Founder of the agentrust-io open standards (TRACE, cMCP, Agent Manifest, cA2A) for hardware-attested agent governance.">
+    <meta name="keywords" content="Imran Siddique, Opaque Systems, Chief Platform Officer, CPO, Microsoft, Agent Governance Toolkit, AGT, Agentic AI, AI Architecture, LLM, Agent OS, AgentMesh, Autonomous Systems, Scale by Subtraction, agentrust-io, TRACE, cMCP, Agent Manifest, Confidential AI, Azure, Machine Learning, AI Governance, AI Safety, OWASP, NIST, Bellevue, Washington">
     <meta name="author" content="Imran Siddique">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
     <link rel="canonical" href="https://imransiddique.com/">
@@ -21,7 +21,7 @@
     <meta property="og:type" content="profile">
     <meta property="og:url" content="https://imransiddique.com/">
     <meta property="og:title" content="Imran Siddique - Agentic AI Architect & Engineering Leader at Opaque Systems">
-    <meta property="og:description" content="Chief Platform Officer at Opaque Systems, previously 18 years at Microsoft. Creator of the Agent Governance Toolkit: 8 packages, 13,000+ tests, 19 framework integrations. Pioneer of Scale by Subtraction methodology.">
+    <meta property="og:description" content="Chief Platform Officer at Opaque Systems, previously 18 years at Microsoft. Creator of the Agent Governance Toolkit: 5 distributions, 5 SDKs, 992 conformance tests, 10/10 OWASP. Founder of the agentrust-io open standards.">
     <meta property="og:site_name" content="Imran Siddique">
     <meta property="og:locale" content="en_US">
     <meta property="og:image" content="https://imransiddique.com/og-image.png">
@@ -35,7 +35,7 @@
     <meta name="twitter:site" content="@mosiddi">
     <meta name="twitter:creator" content="@mosiddi">
     <meta name="twitter:title" content="Imran Siddique - Agentic AI Architect & Engineering Leader">
-    <meta name="twitter:description" content="Chief Platform Officer at Opaque Systems, previously 18 years at Microsoft. Creator of the Agent Governance Toolkit: 8 packages, 13,000+ tests, 19 integrations.">
+    <meta name="twitter:description" content="Chief Platform Officer at Opaque Systems, previously 18 years at Microsoft. Creator of the Agent Governance Toolkit and founder of the agentrust-io open standards.">
     <meta name="twitter:image" content="https://imransiddique.com/og-image.png">
     
     <!-- Fonts -->
@@ -53,7 +53,7 @@
         "givenName": "Imran",
         "familyName": "Siddique",
         "jobTitle": "Chief Platform Officer",
-        "description": "Agentic AI Architect and Engineering Leader. Creator of the Agent Governance Toolkit (microsoft/agent-governance-toolkit): 8 packages, 5 SDKs, 13,000+ tests, 19 framework integrations. Pioneer of Scale by Subtraction methodology",
+        "description": "Chief Platform Officer at Opaque Systems and creator of the Agent Governance Toolkit (microsoft/agent-governance-toolkit): 5 top-level distributions, 5 language SDKs, 992 conformance tests, 10/10 OWASP Agentic Top 10. Founder of the agentrust-io open standards. Pioneer of the Scale by Subtraction methodology",
         "worksFor": {
             "@type": "Organization",
             "name": "Opaque Systems",
@@ -162,7 +162,7 @@
                 "name": "What is the Agent Governance Toolkit?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "The Agent Governance Toolkit (AGT) is an open-source platform under Microsoft providing runtime governance for AI agents. It includes 8 packages (Agent OS, AgentMesh, Agent Runtime, Agent SRE, Agent Compliance, Agent Marketplace, Agent Lightning, Agent Hypervisor), SDKs for 5 languages, 19 framework integrations, and covers all 10 OWASP Agentic AI risks. See https://github.com/microsoft/agent-governance-toolkit"
+                    "text": "The Agent Governance Toolkit (AGT) is an open-source platform hosted under Microsoft providing runtime governance for AI agents. It consolidates 45 packages into 5 top-level distributions, ships SDKs for 5 languages (Python, TypeScript, .NET, Rust, Go), covers all 10 OWASP Agentic AI risks, and has 4,877 GitHub stars. See https://github.com/microsoft/agent-governance-toolkit"
                 }
             },
             {
@@ -240,20 +240,20 @@
         <div class="container">
             <div class="stats-grid">
                 <div class="stat-card">
-                    <div class="stat-value">0%</div>
-                    <div class="stat-label">Safety Violations<br><small style="opacity:0.7">vs 26.67% prompt-based</small></div>
-                </div>
-                <div class="stat-card">
-                    <div class="stat-value">1,590+</div>
+                    <div class="stat-value">4,877</div>
                     <div class="stat-label">GitHub Stars<br><small style="opacity:0.7">microsoft/agent-governance-toolkit</small></div>
                 </div>
                 <div class="stat-card">
-                    <div class="stat-value">19</div>
-                    <div class="stat-label">Framework Integrations<br><small style="opacity:0.7">LangChain · CrewAI · AutoGen · OpenAI · ADK</small></div>
+                    <div class="stat-value">10/10</div>
+                    <div class="stat-label">OWASP Agentic Top 10<br><small style="opacity:0.7">covered by AGT</small></div>
                 </div>
                 <div class="stat-card">
-                    <div class="stat-value">20+</div>
-                    <div class="stat-label">Patents<br><small style="opacity:0.7">data platforms, AI, sustainability</small></div>
+                    <div class="stat-value">5</div>
+                    <div class="stat-label">Language SDKs<br><small style="opacity:0.7">Python · TypeScript · .NET · Rust · Go</small></div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value">18</div>
+                    <div class="stat-label">Years at Microsoft<br><small style="opacity:0.7">before joining Opaque</small></div>
                 </div>
             </div>
         </div>
@@ -262,17 +262,15 @@
     <!-- Integrated With Section -->
     <section class="integrated-section">
         <div class="container integrated-container">
-            <p class="integrated-label">Governance layer integrated with</p>
+            <p class="integrated-label">Current work — open standards for trusted agents</p>
             <div class="integrated-logos">
-                <a href="https://github.com/langgenius/dify-plugins/pull/2060" target="_blank" class="integrated-link">Dify <span class="integrated-stars">65K ⭐</span></a>
-                <a href="https://github.com/run-llama/llama_index/pull/20644" target="_blank" class="integrated-link">LlamaIndex <span class="integrated-stars">47K ⭐</span></a>
-                <a href="https://pypi.org/project/langgraph-trust/" target="_blank" class="integrated-link">LangGraph <span class="integrated-stars">24K ⭐</span></a>
-                <a href="https://pypi.org/project/openai-agents-trust/" target="_blank" class="integrated-link">OpenAI Agents <span class="integrated-stars">19K ⭐</span></a>
-                <a href="https://github.com/microsoft/agent-governance-toolkit/tree/main/examples/crewai-governed" target="_blank" class="integrated-link">CrewAI</a>
-                <a href="https://github.com/microsoft/agent-governance-toolkit/tree/main/examples/smolagents-governed" target="_blank" class="integrated-link">smolagents</a>
-                <a href="https://clawhub.ai/imran-siddique/agentmesh-governance" target="_blank" class="integrated-link">OpenClaw</a>
+                <a href="https://github.com/agentrust-io/trace-spec" target="_blank" class="integrated-link">TRACE</a>
+                <a href="https://cmcp.agentrust-io.com" target="_blank" class="integrated-link">cMCP</a>
+                <a href="https://manifest.agentrust-io.com" target="_blank" class="integrated-link">Agent Manifest</a>
+                <a href="https://github.com/agentrust-io/ca2a" target="_blank" class="integrated-link">cA2A</a>
+                <a href="https://github.com/microsoft/agent-governance-toolkit" target="_blank" class="integrated-link">Agent Governance Toolkit</a>
             </div>
-            <p class="integrated-subtitle">19 framework integrations · Python, TypeScript, .NET, Rust, Go</p>
+            <p class="integrated-subtitle">agentrust-io · hardware-attested governance for autonomous AI agents</p>
         </div>
     </section>
 
@@ -320,12 +318,12 @@
                         <div class="project-header">
                             <div class="project-icon">🏛️</div>
                             <div class="project-meta">
-                                <span class="project-badge">13,000+ tests</span>
+                                <span class="project-badge">992 conformance tests</span>
                                 <span class="project-badge">⭐ Flagship</span>
                             </div>
                         </div>
                         <h3><a href="https://github.com/microsoft/agent-governance-toolkit" target="_blank">Agent Governance Toolkit</a></h3>
-                        <p class="project-description">The unified governance platform for AI agents under Microsoft. 8 packages, 5 language SDKs, 19 framework integrations. OWASP Top 10 coverage, NIST AI RMF alignment, OpenSSF best practices.</p>
+                        <p class="project-description">The unified governance platform for AI agents, hosted under Microsoft. 5 top-level distributions, 5 language SDKs, ~10 framework integrations. 10/10 OWASP Agentic Top 10, NIST AI RMF alignment, OpenSSF best practices.</p>
                         <div class="project-tech">
                             <span class="tech-tag">Python</span>
                             <span class="tech-tag">TypeScript</span>
@@ -334,83 +332,83 @@
                             <span class="tech-tag">Go</span>
                         </div>
                         <div class="project-stats">
-                            <span class="project-stat">📦 pip install agent-governance-toolkit</span>
+                            <span class="project-stat">⭐ 4,877 on GitHub · MIT</span>
                         </div>
                     </article>
 
                     <article class="project-card featured">
                         <div class="project-header">
-                            <div class="project-icon">🛡️</div>
+                            <div class="project-icon">🧾</div>
                             <div class="project-meta">
-                                <span class="project-badge">Core Package</span>
+                                <span class="project-badge">agentrust-io</span>
                             </div>
                         </div>
-                        <h3><a href="https://microsoft.github.io/agent-governance-toolkit/packages/agent-os/" target="_blank">Agent OS</a></h3>
-                        <p class="project-description">The policy engine and governance kernel. Deterministic enforcement, 14 framework adapters, 4-layer privilege architecture.</p>
+                        <h3><a href="https://github.com/agentrust-io/trace-spec" target="_blank">TRACE</a></h3>
+                        <p class="project-description">Trust Runtime Attestation and Compliance Evidence. An open standard for hardware-attested trust records a verifier can check without trusting the operator.</p>
                         <div class="project-tech">
-                            <span class="tech-tag">Python</span>
-                            <span class="tech-tag">MCP</span>
-                            <span class="tech-tag">VS Code</span>
+                            <span class="tech-tag">Attestation</span>
+                            <span class="tech-tag">Open Standard</span>
+                            <span class="tech-tag">Compliance</span>
                         </div>
                         <div class="project-stats">
-                            <span class="project-stat">📦 pip install agent-os-kernel</span>
+                            <span class="project-stat">📦 pip install agentrust-trace</span>
                         </div>
                     </article>
 
                     <article class="project-card featured">
                         <div class="project-header">
-                            <div class="project-icon">🔗</div>
+                            <div class="project-icon">🔐</div>
                             <div class="project-meta">
-                                <span class="project-badge">Core Package</span>
+                                <span class="project-badge">agentrust-io</span>
                             </div>
                         </div>
-                        <h3><a href="https://microsoft.github.io/agent-governance-toolkit/packages/agent-mesh/" target="_blank">AgentMesh</a></h3>
-                        <p class="project-description">Zero-trust identity mesh for AI agents. Ed25519 signatures, trust cards, IATP handshake, cross-org federation.</p>
+                        <h3><a href="https://cmcp.agentrust-io.com" target="_blank">cMCP</a></h3>
+                        <p class="project-description">Confidential MCP gateway. Enforces Model Context Protocol tool-call policy inside a hardware TEE, with the Cedar policy bundle measured into the attestation report and a signed proof per session.</p>
                         <div class="project-tech">
-                            <span class="tech-tag">Python</span>
+                            <span class="tech-tag">MCP</span>
+                            <span class="tech-tag">TEE</span>
+                            <span class="tech-tag">Cedar Policy</span>
+                        </div>
+                        <div class="project-stats">
+                            <span class="project-stat">🌐 cmcp.agentrust-io.com</span>
+                        </div>
+                    </article>
+
+                    <article class="project-card featured">
+                        <div class="project-header">
+                            <div class="project-icon">🪪</div>
+                            <div class="project-meta">
+                                <span class="project-badge">agentrust-io</span>
+                            </div>
+                        </div>
+                        <h3><a href="https://manifest.agentrust-io.com" target="_blank">Agent Manifest</a></h3>
+                        <p class="project-description">A cryptographic identity and provenance standard for AI agents. Hardware-anchors the artifacts that define an agent at deployment, so what is running can be proven, not just claimed.</p>
+                        <div class="project-tech">
+                            <span class="tech-tag">Identity</span>
+                            <span class="tech-tag">Provenance</span>
+                            <span class="tech-tag">Python · TS</span>
+                        </div>
+                        <div class="project-stats">
+                            <span class="project-stat">📦 pip install agent-manifest</span>
+                        </div>
+                    </article>
+
+                    <article class="project-card featured">
+                        <div class="project-header">
+                            <div class="project-icon">🤝</div>
+                            <div class="project-meta">
+                                <span class="project-badge">agentrust-io</span>
+                            </div>
+                        </div>
+                        <h3><a href="https://github.com/agentrust-io/ca2a" target="_blank">cA2A</a></h3>
+                        <p class="project-description">Confidential agent-to-agent. Attested, attenuated delegation and sealed peer channels as a profile on the A2A protocol.</p>
+                        <div class="project-tech">
                             <span class="tech-tag">A2A</span>
-                            <span class="tech-tag">MCP</span>
+                            <span class="tech-tag">Delegation</span>
+                            <span class="tech-tag">TEE</span>
                         </div>
                         <div class="project-stats">
-                            <span class="project-stat">📦 pip install agentmesh-platform</span>
-                        </div>
-                    </article>
-
-                    <article class="project-card featured">
-                        <div class="project-header">
-                            <div class="project-icon">📊</div>
-                            <div class="project-meta">
-                                <span class="project-badge">Core Package</span>
-                            </div>
-                        </div>
-                        <h3><a href="https://microsoft.github.io/agent-governance-toolkit/packages/agent-sre/" target="_blank">Agent SRE</a></h3>
-                        <p class="project-description">Reliability engineering for AI agents. Kill switch, SLO monitoring, chaos testing, cost governance, alert deduplication.</p>
-                        <div class="project-tech">
-                            <span class="tech-tag">Python</span>
-                            <span class="tech-tag">OpenTelemetry</span>
-                            <span class="tech-tag">Prometheus</span>
-                        </div>
-                        <div class="project-stats">
-                            <span class="project-stat">📦 pip install agent-sre</span>
-                        </div>
-                    </article>
-
-                    <article class="project-card featured">
-                        <div class="project-header">
-                            <div class="project-icon">🏗️</div>
-                            <div class="project-meta">
-                                <span class="project-badge">Reference</span>
-                            </div>
-                        </div>
-                        <h3><a href="https://github.com/imran-siddique/agentic-architecture" target="_blank">Agentic Architecture</a></h3>
-                        <p class="project-description">Comprehensive guide to building production AI systems. Documents the Inference Trap, Guardrail Router, and 90/10 Compute-to-Lookup ratio.</p>
-                        <div class="project-tech">
-                            <span class="tech-tag">Architecture</span>
-                            <span class="tech-tag">Best Practices</span>
-                            <span class="tech-tag">Patterns</span>
-                        </div>
-                        <div class="project-stats">
-                            <span class="project-stat">📚 Reference Guide</span>
+                            <span class="project-stat">🔗 github.com/agentrust-io/ca2a</span>
                         </div>
                     </article>
 
@@ -543,7 +541,7 @@
         <section class="content-section" style="text-align: center; padding: var(--space-3xl) 0;">
             <div class="container">
                 <h2 style="font-size: 1.8rem; margin-bottom: var(--space-md);">Ready to Govern Your AI Agents?</h2>
-                <p style="color: var(--text-secondary); max-width: 600px; margin: 0 auto var(--space-xl);">Get started in 30 seconds. Zero policy violations, tamper-evident audit trails, and trust-gated agent handoffs.</p>
+                <p style="color: var(--text-secondary); max-width: 600px; margin: 0 auto var(--space-xl);">Deterministic policy enforcement, tamper-evident audit trails, and trust-gated agent handoffs, all hardware-attested.</p>
                 <div style="display: flex; gap: var(--space-md); justify-content: center; flex-wrap: wrap;">
                     <a href="https://github.com/microsoft/agent-governance-toolkit" class="btn btn-primary" target="_blank">⭐ Star on GitHub</a>
                     <a href="https://microsoft.github.io/agent-governance-toolkit/quickstart/" class="btn btn-primary" style="background: transparent; border: 1px solid var(--accent-primary); color: var(--accent-primary);" target="_blank">Quick Start Guide</a>

--- a/llms.txt
+++ b/llms.txt
@@ -1,46 +1,48 @@
-# Imran Siddique - Agent Governance Toolkit
+# Imran Siddique - Chief Platform Officer at Opaque Systems
 
-> Chief Platform Officer at Opaque Systems; creator of the Agent Governance Toolkit — runtime governance for autonomous AI agents.
+> Chief Platform Officer at Opaque Systems, creator of the Agent Governance Toolkit, and founder of the agentrust-io open standards for hardware-attested agent governance.
 
 ## About
 
-Imran Siddique is Chief Platform Officer at Opaque Systems, and previously spent 18 years at Microsoft, where he earned 20+ patents. He created the Agent Governance Toolkit (AGT), an open-source platform (github.com/microsoft/agent-governance-toolkit) providing deterministic policy enforcement, zero-trust identity, execution sandboxing, and SRE for autonomous AI agents. AGT includes 8 packages, SDKs for 5 languages (Python, TypeScript, .NET, Rust, Go), 13,000+ tests, and 19 framework integrations covering all 10 OWASP Agentic AI risks. His methodology, "Scale by Subtraction," advocates removing complexity rather than adding features to build reliable AI systems.
+Imran Siddique is Chief Platform Officer at Opaque Systems, the confidential AI company. He previously spent 18 years at Microsoft, where he holds granted and published patents in data platforms, sustainability, and AI systems. He created the Agent Governance Toolkit (AGT), an open-source platform (github.com/microsoft/agent-governance-toolkit, MIT) providing deterministic policy enforcement, zero-trust identity, execution sandboxing, and reliability engineering for autonomous AI agents. AGT consolidates 45 packages into 5 top-level distributions, ships SDKs for 5 languages (Python, TypeScript, .NET, Rust, Go), covers all 10 OWASP Agentic AI risks, and has 4,877 GitHub stars. His methodology, "Scale by Subtraction," advocates removing complexity rather than adding features to build reliable AI systems.
 
-## Projects
+## Current Work: agentrust-io Open Standards
 
-### Agent Governance Toolkit (Flagship)
-- Description: Unified governance platform for AI agents under Microsoft
-- Packages: 8 (Agent OS, AgentMesh, Agent Runtime, Agent SRE, Agent Compliance, Agent Marketplace, Agent Lightning, Agent Hypervisor)
+### TRACE
+- Description: Trust Runtime Attestation and Compliance Evidence, an open standard for hardware-attested trust records a verifier can check without trusting the operator
+- Install: pip install agentrust-trace
+- GitHub: https://github.com/agentrust-io/trace-spec
+
+### cMCP
+- Description: Confidential MCP gateway, enforcing MCP tool-call policy inside a hardware TEE with the Cedar policy bundle measured into the attestation report and a signed proof per session
+- Site: https://cmcp.agentrust-io.com
+- GitHub: https://github.com/agentrust-io/cmcp
+
+### Agent Manifest
+- Description: Cryptographic identity and provenance standard that hardware-anchors the artifacts defining an agent at deployment
+- Install: pip install agent-manifest
+- Site: https://manifest.agentrust-io.com
+
+### cA2A
+- Description: Confidential agent-to-agent, attested and attenuated delegation and sealed peer channels as a profile on A2A
+- GitHub: https://github.com/agentrust-io/ca2a
+
+## Agent Governance Toolkit (Flagship)
+
+- Description: Open-source platform for runtime governance of AI agents, hosted under Microsoft
+- License: MIT
+- Distributions: 5 top-level (45 packages consolidated)
 - Languages: Python, TypeScript, .NET, Rust, Go
-- Tests: 13,000+
-- Integrations: 19 (LangChain, CrewAI, AutoGen, Google ADK, OpenAI Agents, LlamaIndex, Haystack, Mastra, MCP, A2A, and more)
-- Standards: OWASP Agentic AI Top 10, NIST AI RMF 1.0, RFC 8032 (Ed25519), RFC 9334 (RATS)
-- Install: pip install agent-governance-toolkit
+- Tests: 992 conformance tests
+- Integrations: ~10 agent frameworks (LangChain, CrewAI, AutoGen, Google ADK, OpenAI Agents, LlamaIndex, smolagents, plus MCP and A2A)
+- Standards: OWASP Agentic AI Top 10 (10/10), NIST AI RMF 1.0
+- Stars: 4,877
 - GitHub: https://github.com/microsoft/agent-governance-toolkit
 - Docs: https://microsoft.github.io/agent-governance-toolkit/
 
-### Agent OS (Core Package)
-- Description: Policy engine and governance kernel with deterministic enforcement
-- Install: pip install agent-os-kernel
-- Docs: https://microsoft.github.io/agent-governance-toolkit/packages/agent-os/
+## Prior Work (consolidated into AGT)
 
-### AgentMesh (Core Package)
-- Description: Zero-trust identity mesh with Ed25519 signatures and trust cards
-- Install: pip install agentmesh-platform
-- Docs: https://microsoft.github.io/agent-governance-toolkit/packages/agent-mesh/
-
-### Agent SRE (Core Package)
-- Description: Reliability engineering — kill switch, SLO monitoring, chaos testing, cost governance
-- Install: pip install agent-sre
-- Docs: https://microsoft.github.io/agent-governance-toolkit/packages/agent-sre/
-
-### Agent Runtime (Core Package)
-- Description: Execution sandboxing with four privilege rings
-- Docs: https://microsoft.github.io/agent-governance-toolkit/packages/agent-runtime/
-
-### Agent Compliance (Core Package)
-- Description: Audit logging, compliance frameworks, integrity verification
-- Docs: https://microsoft.github.io/agent-governance-toolkit/packages/agent-compliance/
+Agent OS (policy engine, pip install agent-os-kernel), AgentMesh (zero-trust identity, pip install agentmesh-platform), and Agent SRE (reliability engineering) began as standalone projects and are now part of the Agent Governance Toolkit. Their original repositories are marked deprecated and point to AGT.
 
 ## Key Concepts
 
@@ -48,16 +50,17 @@ Imran Siddique is Chief Platform Officer at Opaque Systems, and previously spent
 Methodology: deterministic control planes over probabilistic prompts, knowledge graphs over context windows, silent agent coordination over chat interfaces.
 
 ### Standards Compliance
-- OWASP Agentic AI Top 10: All 10 risks covered with deterministic controls
-- NIST AI RMF 1.0: Full GOVERN, MAP, MEASURE, MANAGE alignment
-- Ed25519 (RFC 8032): Agent identity signatures
-- RFC 9334 (RATS): Remote attestation alignment
+- OWASP Agentic AI Top 10: all 10 risks covered with deterministic controls
+- NIST AI RMF 1.0: GOVERN, MAP, MEASURE, MANAGE alignment
+- Ed25519 (RFC 8032): agent identity signatures
+- RFC 9334 (RATS): remote attestation alignment
 
 ## Links
 - Website: https://imransiddique.com
+- Opaque Systems: https://www.opaque.co
+- agentrust-io: https://agentrust-io.com
 - GitHub: https://github.com/imran-siddique
 - AGT GitHub: https://github.com/microsoft/agent-governance-toolkit
-- AGT Docs: https://microsoft.github.io/agent-governance-toolkit/
 - LinkedIn: https://www.linkedin.com/in/imransiddique1986/
 - Medium: https://medium.com/@isiddique
 - Dev.to: https://dev.to/mosiddi

--- a/projects.html
+++ b/projects.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Open source AI projects by Imran Siddique: Agent Governance Toolkit (8 packages, 13,000+ tests, 19 integrations), Agent OS (policy engine), AgentMesh (zero-trust identity), Agent SRE (reliability engineering), and Scale by Subtraction methodology. Under Microsoft, covering OWASP Top 10 and NIST AI RMF.">
+    <meta name="description" content="Open-source AI projects by Imran Siddique: the agentrust-io open standards (TRACE, cMCP, Agent Manifest, cA2A) for hardware-attested agent governance, and the Agent Governance Toolkit (hosted under Microsoft) covering the OWASP Agentic Top 10 and NIST AI RMF.">
     <meta name="keywords" content="Agent OS, AgentMesh, Agent SRE, AgentMesh Integrations, Agentic Architecture, Scale by Subtraction, AI Agents, Open Source, Python, LLM Governance, AI Safety, SRE, Chaos Testing, OpenTelemetry, Autonomous Systems, Imran Siddique, Dify, LlamaIndex, Agent-Lightning">
     <meta name="author" content="Imran Siddique">
     <meta name="robots" content="index, follow">
@@ -13,14 +13,14 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://imransiddique.com/projects.html">
     <meta property="og:title" content="Open Source AI Projects - Imran Siddique">
-    <meta property="og:description" content="Production-ready open source projects for autonomous AI systems: Agent OS (0% safety violations), AgentMesh (identity & trust), Agent SRE (reliability engineering), and community integrations.">
+    <meta property="og:description" content="Open standards for autonomous AI systems: TRACE attestation, Confidential MCP, and Agent Manifest, plus the Agent Governance Toolkit hosted under Microsoft.">
     <meta property="og:site_name" content="Imran Siddique">
     
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@mosiddi">
     <meta name="twitter:title" content="Open Source AI Projects - Imran Siddique">
-    <meta name="twitter:description" content="Production-ready infrastructure for autonomous AI systems. Agent OS achieves 0% safety violations. AgentMesh provides identity & trust. Agent SRE adds reliability engineering.">
+    <meta name="twitter:description" content="Open standards for autonomous AI systems: TRACE attestation, Confidential MCP, and Agent Manifest, plus the Agent Governance Toolkit hosted under Microsoft.">
     
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -42,11 +42,11 @@
         "mainEntity": {
             "@type": "ItemList",
             "itemListElement": [
-                {"@type": "SoftwareSourceCode", "name": "Agent OS", "description": "Safety-First Kernel for Autonomous AI Agents with 0% policy violations, 734 tests, POSIX-inspired primitives, VS Code extension, and MCP server", "codeRepository": "https://github.com/imran-siddique/agent-os", "programmingLanguage": "Python"},
-                {"@type": "SoftwareSourceCode", "name": "AgentMesh", "description": "The secure nervous system for cloud-native agent ecosystems - Identity, Trust, Reward, Governance for AI agents", "codeRepository": "https://github.com/imran-siddique/agent-mesh", "programmingLanguage": "Python"},
-                {"@type": "SoftwareSourceCode", "name": "Agent SRE", "description": "Reliability engineering framework for AI agents - SLO engine, chaos engineering, replay debugging, cost guard. 878 tests, 20K+ lines", "codeRepository": "https://github.com/imran-siddique/agent-sre", "programmingLanguage": "Python"},
-                {"@type": "SoftwareSourceCode", "name": "Agentic Architecture", "description": "Comprehensive guide to modern agentic system design principles and patterns", "codeRepository": "https://github.com/imran-siddique/agentic-architecture"},
-                {"@type": "SoftwareSourceCode", "name": "AgentMesh Integrations", "description": "Community integrations for AgentMesh - platform plugins and trust providers", "codeRepository": "https://github.com/imran-siddique/agentmesh-integrations", "programmingLanguage": "Python"}
+                {"@type": "SoftwareSourceCode", "name": "TRACE", "description": "Trust Runtime Attestation and Compliance Evidence - an open standard for hardware-attested trust records for AI agents", "codeRepository": "https://github.com/agentrust-io/trace-spec"},
+                {"@type": "SoftwareSourceCode", "name": "cMCP", "description": "Confidential MCP gateway - enforces MCP tool-call policy inside a hardware TEE with signed per-session proofs", "codeRepository": "https://github.com/agentrust-io/cmcp", "programmingLanguage": "Python"},
+                {"@type": "SoftwareSourceCode", "name": "Agent Manifest", "description": "Cryptographic identity and provenance standard that hardware-anchors the artifacts defining an agent at deployment", "codeRepository": "https://github.com/agentrust-io/agent-manifest", "programmingLanguage": "Python"},
+                {"@type": "SoftwareSourceCode", "name": "cA2A", "description": "Confidential agent-to-agent - attested, attenuated delegation and sealed peer channels as a profile on A2A", "codeRepository": "https://github.com/agentrust-io/ca2a"},
+                {"@type": "SoftwareSourceCode", "name": "Agent Governance Toolkit", "description": "Open-source platform for runtime governance of AI agents, hosted under Microsoft: policy enforcement, identity, sandboxing, SRE. 4,877 stars, MIT", "codeRepository": "https://github.com/microsoft/agent-governance-toolkit", "programmingLanguage": "Python"}
             ]
         }
     }
@@ -92,221 +92,202 @@
         <section class="content-section">
             <div class="container">
                 <div class="projects-intro">
-                    <p class="lead">I build the <a href="https://github.com/microsoft/agent-governance-toolkit" target="_blank" style="color: var(--accent-primary);">Agent Governance Toolkit</a> under Microsoft: 8 packages, 5 SDKs, 13,000+ tests, 19 framework integrations. Runtime governance for autonomous AI agents.</p>
+                    <p class="lead">As Chief Platform Officer at <a href="https://www.opaque.co" target="_blank" style="color: var(--accent-primary);">Opaque Systems</a>, I build open standards for running autonomous agents with verifiable, hardware-attested trust. My current work lives in the <a href="https://agentrust-io.com" target="_blank" style="color: var(--accent-primary);">agentrust-io</a> project, and I created the <a href="https://github.com/microsoft/agent-governance-toolkit" target="_blank" style="color: var(--accent-primary);">Agent Governance Toolkit</a> hosted under Microsoft.</p>
                 </div>
 
+                <h2 style="margin-top: 2rem;">🔭 Current Work: agentrust-io Open Standards</h2>
+                <div class="projects-grid">
+                    <article class="project-card featured">
+                        <div class="project-header">
+                            <div class="project-icon">🧾</div>
+                            <div class="project-stars">Open Standard</div>
+                        </div>
+                        <h3>TRACE</h3>
+                        <p class="project-description">Trust Runtime Attestation and Compliance Evidence. A standard for hardware-attested trust records that a verifier can check without trusting the operator running the agent.</p>
+                        <div class="project-tech">
+                            <span class="tech-badge">Attestation</span>
+                            <span class="tech-badge">Compliance</span>
+                            <span class="tech-badge">Python</span>
+                        </div>
+                        <div class="project-links">
+                            <a href="https://github.com/agentrust-io/trace-spec" target="_blank" rel="noopener noreferrer" class="btn-primary">
+                                View spec on GitHub →
+                            </a>
+                        </div>
+                    </article>
+
+                    <article class="project-card featured">
+                        <div class="project-header">
+                            <div class="project-icon">🔐</div>
+                            <div class="project-stars">Live</div>
+                        </div>
+                        <h3>cMCP</h3>
+                        <p class="project-description">Confidential MCP gateway. Every Model Context Protocol tool call is evaluated against a Cedar policy bundle inside a hardware TEE, with the bundle hash measured into the attestation report and a signed proof produced per session.</p>
+                        <div class="project-highlights">
+                            <h4>Key Ideas:</h4>
+                            <ul>
+                                <li><strong>TEE-enforced:</strong> policy runs where the governed process cannot reach it</li>
+                                <li><strong>Measured policy:</strong> Cedar bundle hash bound into the hardware attestation</li>
+                                <li><strong>Providers:</strong> TPM, AMD SEV-SNP, Intel TDX, OPAQUE</li>
+                            </ul>
+                        </div>
+                        <div class="project-tech">
+                            <span class="tech-badge">MCP</span>
+                            <span class="tech-badge">TEE</span>
+                            <span class="tech-badge">Cedar</span>
+                        </div>
+                        <div class="project-links">
+                            <a href="https://cmcp.agentrust-io.com" target="_blank" rel="noopener noreferrer" class="btn-primary">
+                                cmcp.agentrust-io.com →
+                            </a>
+                        </div>
+                    </article>
+
+                    <article class="project-card featured">
+                        <div class="project-header">
+                            <div class="project-icon">🪪</div>
+                            <div class="project-stars">Live</div>
+                        </div>
+                        <h3>Agent Manifest</h3>
+                        <p class="project-description">A cryptographic identity and provenance standard for AI agents. It hardware-anchors the artifacts that define an agent at deployment, so what is actually running can be proven rather than asserted.</p>
+                        <div class="project-tech">
+                            <span class="tech-badge">Identity</span>
+                            <span class="tech-badge">Provenance</span>
+                            <span class="tech-badge">Python · TS</span>
+                        </div>
+                        <div class="project-links">
+                            <a href="https://manifest.agentrust-io.com" target="_blank" rel="noopener noreferrer" class="btn-primary">
+                                manifest.agentrust-io.com →
+                            </a>
+                        </div>
+                    </article>
+
+                    <article class="project-card featured">
+                        <div class="project-header">
+                            <div class="project-icon">🤝</div>
+                            <div class="project-stars">Open Standard</div>
+                        </div>
+                        <h3>cA2A</h3>
+                        <p class="project-description">Confidential agent-to-agent. Attested, attenuated delegation and sealed peer channels expressed as a profile on the A2A protocol.</p>
+                        <div class="project-tech">
+                            <span class="tech-badge">A2A</span>
+                            <span class="tech-badge">Delegation</span>
+                            <span class="tech-badge">TEE</span>
+                        </div>
+                        <div class="project-links">
+                            <a href="https://github.com/agentrust-io/ca2a" target="_blank" rel="noopener noreferrer" class="btn-primary">
+                                View on GitHub →
+                            </a>
+                        </div>
+                    </article>
+                </div>
+
+                <h2 style="margin-top: 3rem;">🏛️ Agent Governance Toolkit</h2>
                 <div class="projects-grid">
                     <article class="project-card featured">
                         <div class="project-header">
                             <div class="project-icon">🛡️</div>
-                            <div class="project-stars">⭐ Featured | 📦 v1.0.0</div>
+                            <div class="project-stars">⭐ 4,877 | MIT</div>
+                        </div>
+                        <h3>Agent Governance Toolkit</h3>
+                        <p class="project-description">The open-source platform I created for runtime governance of AI agents, now hosted under Microsoft. Policy enforcement, zero-trust identity, execution sandboxing, and reliability engineering for autonomous agents.</p>
+                        <div class="project-highlights">
+                            <h4>By the numbers:</h4>
+                            <ul>
+                                <li><strong>5</strong> top-level distributions (45 packages consolidated)</li>
+                                <li><strong>5</strong> language SDKs: Python, TypeScript, .NET, Rust, Go</li>
+                                <li><strong>992</strong> conformance tests</li>
+                                <li><strong>10/10</strong> OWASP Agentic AI Top 10, NIST AI RMF alignment</li>
+                            </ul>
+                        </div>
+                        <div class="project-tech">
+                            <span class="tech-badge">Python</span>
+                            <span class="tech-badge">TypeScript</span>
+                            <span class="tech-badge">.NET</span>
+                            <span class="tech-badge">Rust</span>
+                            <span class="tech-badge">Go</span>
+                        </div>
+                        <div class="project-links">
+                            <a href="https://github.com/microsoft/agent-governance-toolkit" target="_blank" rel="noopener noreferrer" class="btn-primary">
+                                View on GitHub →
+                            </a>
+                        </div>
+                    </article>
+                </div>
+
+                <h2 style="margin-top: 3rem;">🧱 Prior Work (consolidated into AGT)</h2>
+                <p style="margin-bottom: 1rem; color: var(--text-secondary);">These began as standalone projects and were folded into the Agent Governance Toolkit. Their original repositories are now marked deprecated and point to AGT.</p>
+                <div class="projects-grid">
+                    <article class="project-card">
+                        <div class="project-header">
+                            <div class="project-icon">⚙️</div>
+                            <div class="project-stars">Consolidated → AGT</div>
                         </div>
                         <h3>Agent OS</h3>
-                        <p class="project-description">A Safety-First Kernel for Autonomous AI Agents. POSIX-inspired primitives with 0% policy violation guarantee. The operating system layer that treats LLMs as raw compute and provides deterministic governance.</p>
-                        
-                        <div class="project-highlights">
-                            <h4>Key Features:</h4>
-                            <ul>
-                                <li><strong>4-Layer Architecture:</strong> Primitives, Infrastructure, Control Plane, Intelligence</li>
-                                <li><strong>IDE Extensions:</strong> VS Code, Copilot, Cursor, JetBrains plugins</li>
-                                <li><strong>MCP Server:</strong> Works with Claude Desktop, Copilot, and Cursor</li>
-                            </ul>
-                        </div>
-
-                        <div class="project-benchmark">
-                            <strong>🎯 Results:</strong> 0% policy violations vs 26.67% for prompt-based safety • Part of AGT (13,000+ tests)
-                        </div>
-
+                        <p class="project-description">The policy engine and governance kernel: deterministic enforcement with POSIX-inspired primitives and a layered privilege architecture. Now the policy core of AGT.</p>
                         <div class="project-tech">
                             <span class="tech-badge">Python</span>
-                            <span class="tech-badge">PyPI</span>
                             <span class="tech-badge">MCP</span>
-                            <span class="tech-badge">VS Code</span>
+                            <span class="tech-badge">Policy</span>
                         </div>
-
                         <div class="project-links">
-                            <a href="https://github.com/imran-siddique/agent-os" target="_blank" rel="noopener noreferrer" class="btn-primary">
-                                View on GitHub →
-                            </a>
-                        </div>
-                    </article>
-
-                    <article class="project-card featured">
-                        <div class="project-header">
-                            <div class="project-icon">🔗</div>
-                            <div class="project-stars">⭐ Featured | 🆕 New</div>
-                        </div>
-                        <h3>AgentMesh</h3>
-                        <p class="project-description">The Secure Nervous System for Cloud-Native Agent Ecosystems. Identity, Trust, Reward, and Governance for the governed agent mesh. The trust layer that A2A and MCP protocols are missing.</p>
-                        
-                        <div class="project-highlights">
-                            <h4>Key Features:</h4>
-                            <ul>
-                                <li><strong>Identity & Zero-Trust:</strong> Agent identity and ephemeral credentials</li>
-                                <li><strong>Trust & Protocol Bridge:</strong> A2A, MCP support</li>
-                                <li><strong>Governance & Compliance:</strong> EU AI Act, SOC 2, HIPAA, GDPR</li>
-                            </ul>
-                        </div>
-
-                        <div class="project-benchmark">
-                            <strong>🔒 Trust:</strong> Ephemeral credentials • Per-agent trust scores • Audit logs
-                        </div>
-
-                        <div class="project-tech">
-                            <span class="tech-badge">Python</span>
-                            <span class="tech-badge">A2A</span>
-                            <span class="tech-badge">MCP</span>
-                            <span class="tech-badge">Trust</span>
-                        </div>
-
-                        <div class="project-links">
-                            <a href="https://github.com/imran-siddique/agent-mesh" target="_blank" rel="noopener noreferrer" class="btn-primary">
-                                View on GitHub →
-                            </a>
-                        </div>
-                    </article>
-
-                    <article class="project-card featured">
-                        <div class="project-header">
-                            <div class="project-icon">🔧</div>
-                            <div class="project-stars">⭐ Featured | 📦 v1.0.0</div>
-                        </div>
-                        <h3>Agent SRE</h3>
-                        <p class="project-description">Reliability engineering framework for AI agent systems. SLO engine, chaos engineering, replay debugging, progressive delivery, cost guard, and incident management—purpose-built for autonomous agents.</p>
-                        
-                        <div class="project-highlights">
-                            <h4>Key Features:</h4>
-                            <ul>
-                                <li><strong>SLO Engine:</strong> Reliability targets for task success rate, cost per task, hallucination rate</li>
-                                <li><strong>Replay Engine:</strong> Time-travel debugging with deterministic replay and trace diffing</li>
-                                <li><strong>Chaos Engineering:</strong> 9 pre-built fault injection templates with resilience scoring</li>
-                                <li><strong>Cost Guard:</strong> Per-task limits, anomaly detection, auto-throttle</li>
-                                <li><strong>Progressive Delivery:</strong> Shadow mode, canary rollouts, auto-rollback</li>
-                            </ul>
-                        </div>
-
-                        <div class="project-benchmark">
-                            <strong>📊 Scale:</strong> Part of AGT (13,000+ tests) • 20+ tool integrations (OTEL, Datadog, Prometheus)
-                        </div>
-
-                        <div class="project-tech">
-                            <span class="tech-badge">Python</span>
-                            <span class="tech-badge">OpenTelemetry</span>
-                            <span class="tech-badge">Prometheus</span>
-                            <span class="tech-badge">Kubernetes</span>
-                        </div>
-
-                        <div class="project-links">
-                            <a href="https://github.com/imran-siddique/agent-sre" target="_blank" rel="noopener noreferrer" class="btn-primary">
-                                View on GitHub →
-                            </a>
-                        </div>
-                    </article>
-
-                    <article class="project-card featured">
-                        <div class="project-header">
-                            <div class="project-icon">📐</div>
-                            <div class="project-stars">⭐ 1</div>
-                        </div>
-                        <h3>Agentic Architecture</h3>
-                        <p class="project-description">A comprehensive guide to modern agentic system design. Documents revolutionary architectural patterns for building production-grade AI agent systems based on real-world experience.</p>
-                        
-                        <div class="project-highlights">
-                            <h4>Core Concepts:</h4>
-                            <ul>
-                                <li><strong>The Inference Trap:</strong> Why "thinking" is technical debt</li>
-                                <li><strong>The Guardrail Router:</strong> Intelligent request routing</li>
-                                <li><strong>Compute-to-Lookup Ratio:</strong> 90/10 rule for performance</li>
-                                <li><strong>Multidimensional Knowledge Graphs:</strong> Semantic firewalls</li>
-                                <li><strong>The Headless Agent:</strong> Silent swarms for coordination</li>
-                                <li><strong>Recursive Ontologies:</strong> Self-updating knowledge systems</li>
-                            </ul>
-                        </div>
-
-                        <div class="project-philosophy">
-                            <em>"If your agent is 'thinking' for every request, you haven't built an agent; you've built a philosophy major. In production, we need engineers, not philosophers."</em>
-                        </div>
-
-                        <div class="project-tech">
-                            <span class="tech-badge">Architecture</span>
-                            <span class="tech-badge">Documentation</span>
-                            <span class="tech-badge">Best Practices</span>
-                        </div>
-
-                        <div class="project-links">
-                            <a href="https://github.com/imran-siddique/agentic-architecture" target="_blank" rel="noopener noreferrer" class="btn-primary">
-                                View on GitHub →
-                            </a>
-                        </div>
-                    </article>
-
-                    <article class="project-card featured">
-                        <div class="project-header">
-                            <div class="project-icon">📊</div>
-                            <div class="project-stars">⭐ Featured | ⭐ 2</div>
-                        </div>
-                        <h3>Agent SRE</h3>
-                        <p class="project-description">Reliability Engineering for AI Agent Systems. SLOs, error budgets, chaos testing, deterministic replay, and progressive delivery for multi-agent production environments. Part of the Agent OS + AgentMesh governance stack.</p>
-                        
-                        <div class="project-highlights">
-                            <h4>Core Capabilities:</h4>
-                            <ul>
-                                <li><strong>SLO Engine:</strong> Define reliability targets (task success, cost, latency, hallucination rate)</li>
-                                <li><strong>Replay Engine:</strong> Deterministic time-travel debugging for agent decisions</li>
-                                <li><strong>Progressive Delivery:</strong> Shadow mode, canary rollouts, auto-rollback</li>
-                                <li><strong>Chaos Testing:</strong> Fault injection, resilience scoring, 9 experiment templates</li>
-                                <li><strong>Cost Guard:</strong> Budgets, anomaly detection, auto-throttle, kill switch</li>
-                                <li><strong>Incident Manager:</strong> SLO breach detection, circuit breaker, postmortems</li>
-                            </ul>
-                        </div>
-
-                        <div class="project-benchmark">
-                            <strong>🎯 Production Ready:</strong> Part of AGT (13,000+ tests) • Full OpenTelemetry integration
-                        </div>
-
-                        <div class="project-tech">
-                            <span class="tech-badge">Python</span>
-                            <span class="tech-badge">SRE</span>
-                            <span class="tech-badge">OpenTelemetry</span>
-                            <span class="tech-badge">Chaos</span>
-                        </div>
-
-                        <div class="project-links">
-                            <a href="https://github.com/imran-siddique/agent-sre" target="_blank" rel="noopener noreferrer" class="btn-primary">
-                                View on GitHub →
+                            <a href="https://microsoft.github.io/agent-governance-toolkit/packages/agent-os/" target="_blank" rel="noopener noreferrer" class="btn-primary">
+                                Docs →
                             </a>
                         </div>
                     </article>
 
                     <article class="project-card">
                         <div class="project-header">
-                            <div class="project-icon">🔌</div>
-                            <div class="project-stars">Community</div>
+                            <div class="project-icon">🔗</div>
+                            <div class="project-stars">Consolidated → AGT</div>
                         </div>
-                        <h3>AgentMesh Integrations</h3>
-                        <p class="project-description">Community integrations for AgentMesh — platform plugins and trust providers. Dify, LangChain, LlamaIndex, Agent Lightning, Nostr Web of Trust, and Moltbook integrations for identity, trust, and governance.</p>
-                        
-                        <div class="project-highlights">
-                            <h4>Available Integrations:</h4>
-                            <ul>
-                                <li><strong>LangChain:</strong> Ed25519 identity, trust-gated tools, delegation chains</li>
-                                <li><strong>LlamaIndex:</strong> Trust-verified workers, identity-aware query engines</li>
-                                <li><strong>Dify Plugin:</strong> Packaged .difypkg with peer verification and trust scoring</li>
-                                <li><strong>Agent Lightning:</strong> Agent-OS governance adapters, reward shaping</li>
-                                <li><strong>Moltbook:</strong> AgentMesh governance skill for agent registry</li>
-                                <li><strong>Nostr WoT:</strong> Decentralized trust scoring integration</li>
-                            </ul>
-                        </div>
-
+                        <h3>AgentMesh</h3>
+                        <p class="project-description">Zero-trust identity mesh for AI agents: Ed25519 identity, trust cards, and cross-org federation. Now the identity layer of AGT.</p>
                         <div class="project-tech">
-                            <span class="tech-badge">Python</span>
-                            <span class="tech-badge">Integrations</span>
-                            <span class="tech-badge">Trust</span>
                             <span class="tech-badge">Identity</span>
+                            <span class="tech-badge">A2A</span>
+                            <span class="tech-badge">MCP</span>
                         </div>
-
                         <div class="project-links">
-                            <a href="https://github.com/imran-siddique/agentmesh-integrations" target="_blank" rel="noopener noreferrer" class="btn-primary">
+                            <a href="https://microsoft.github.io/agent-governance-toolkit/packages/agent-mesh/" target="_blank" rel="noopener noreferrer" class="btn-primary">
+                                Docs →
+                            </a>
+                        </div>
+                    </article>
+
+                    <article class="project-card">
+                        <div class="project-header">
+                            <div class="project-icon">📊</div>
+                            <div class="project-stars">Consolidated → AGT</div>
+                        </div>
+                        <h3>Agent SRE</h3>
+                        <p class="project-description">Reliability engineering for AI agents: SLO engine, chaos testing, deterministic replay, cost guard, and progressive delivery. Now the reliability layer of AGT.</p>
+                        <div class="project-tech">
+                            <span class="tech-badge">SRE</span>
+                            <span class="tech-badge">OpenTelemetry</span>
+                            <span class="tech-badge">Chaos</span>
+                        </div>
+                        <div class="project-links">
+                            <a href="https://microsoft.github.io/agent-governance-toolkit/packages/agent-sre/" target="_blank" rel="noopener noreferrer" class="btn-primary">
+                                Docs →
+                            </a>
+                        </div>
+                    </article>
+
+                    <article class="project-card">
+                        <div class="project-header">
+                            <div class="project-icon">📐</div>
+                            <div class="project-stars">Reference</div>
+                        </div>
+                        <h3>Agentic Architecture</h3>
+                        <p class="project-description">A written guide to production agentic system design: the Inference Trap, the Guardrail Router, and the compute-to-lookup ratio.</p>
+                        <div class="project-tech">
+                            <span class="tech-badge">Architecture</span>
+                            <span class="tech-badge">Patterns</span>
+                        </div>
+                        <div class="project-links">
+                            <a href="https://github.com/imran-siddique/agentic-architecture" target="_blank" rel="noopener noreferrer" class="btn-primary">
                                 View on GitHub →
                             </a>
                         </div>
@@ -315,60 +296,17 @@
                     <article class="project-card">
                         <div class="project-header">
                             <div class="project-icon">🔬</div>
-                            <div class="project-stars">Research</div>
+                            <div class="project-stars">Methodology</div>
                         </div>
                         <h3>Scale by Subtraction</h3>
-                        <p class="project-description">My core methodology for building reliable AI systems. Focus on removing complexity rather than adding features. Via Negativa applied to software architecture and AI safety.</p>
-                        
-                        <div class="project-highlights">
-                            <h4>Key Principles:</h4>
-                            <ul>
-                                <li><strong>Control Planes over Prompts:</strong> Deterministic enforcement</li>
-                                <li><strong>Graphs over Context:</strong> Prevent hallucinations structurally</li>
-                                <li><strong>Silent Swarms over Chat:</strong> Structured data communication</li>
-                                <li><strong>Memory Hygiene:</strong> Agents that know how to forget</li>
-                            </ul>
-                        </div>
-
+                        <p class="project-description">My methodology for reliable AI systems: remove complexity rather than add features. Control planes over prompts, graphs over context, silent swarms over chat.</p>
                         <div class="project-tech">
                             <span class="tech-badge">Methodology</span>
                             <span class="tech-badge">AI Safety</span>
-                            <span class="tech-badge">Architecture</span>
                         </div>
-
                         <div class="project-links">
                             <a href="writings.html" class="btn-primary">
-                                Read About It →
-                            </a>
-                        </div>
-                    </article>
-
-                    <article class="project-card">
-                        <div class="project-header">
-                            <div class="project-icon">📝</div>
-                            <div class="project-stars">Writing</div>
-                        </div>
-                        <h3>Technical Articles</h3>
-                        <p class="project-description">Deep dives into agentic systems, architectural patterns, and the philosophy of building AI that works. Published on Medium, Dev.to, and LinkedIn with practical, battle-tested approaches.</p>
-                        
-                        <div class="project-highlights">
-                            <h4>Featured Series:</h4>
-                            <ul>
-                                <li><strong>The Accumulation Paradox:</strong> Why agents degrade over time</li>
-                                <li><strong>The Mute Agent:</strong> Shut up and listen to the graph</li>
-                                <li><strong>The Agentic Architect:</strong> Building AI governance systems</li>
-                            </ul>
-                        </div>
-
-                        <div class="project-tech">
-                            <span class="tech-badge">Medium</span>
-                            <span class="tech-badge">Dev.to</span>
-                            <span class="tech-badge">LinkedIn</span>
-                        </div>
-
-                        <div class="project-links">
-                            <a href="https://medium.com/@isiddique" target="_blank" rel="noopener noreferrer" class="btn-primary">
-                                Read on Medium →
+                                Read about it →
                             </a>
                         </div>
                     </article>
@@ -376,40 +314,16 @@
                     <article class="project-card">
                         <div class="project-header">
                             <div class="project-icon">🌐</div>
-                            <div class="project-stars">Ecosystem</div>
+                            <div class="project-stars">Curated</div>
                         </div>
                         <h3>Awesome AI Governance</h3>
-                        <p class="project-description">Curated list of tools, frameworks, and resources integrated with the Agent OS + AgentMesh + Agent SRE governance stack. The definitive resource for AI agent governance.</p>
-                        
+                        <p class="project-description">A curated list of tools, frameworks, standards, and resources for AI agent governance, safety, and compliance.</p>
                         <div class="project-tech">
                             <span class="tech-badge">Curated List</span>
-                            <span class="tech-badge">Ecosystem</span>
                             <span class="tech-badge">Resources</span>
                         </div>
-
                         <div class="project-links">
-                            <a href="https://github.com/imran-siddique/awesome-ai-governance" target="_blank" rel="noopener noreferrer" class="btn-primary">
-                                View on GitHub →
-                            </a>
-                        </div>
-                    </article>
-
-                    <article class="project-card">
-                        <div class="project-header">
-                            <div class="project-icon">🔌</div>
-                            <div class="project-stars">Plugins</div>
-                        </div>
-                        <h3>AgentMesh Integrations</h3>
-                        <p class="project-description">Platform plugins and trust providers for AgentMesh. Includes the Dify Trust Layer plugin (merged into Dify Marketplace) and framework-specific governance adapters.</p>
-                        
-                        <div class="project-tech">
-                            <span class="tech-badge">Dify</span>
-                            <span class="tech-badge">Plugins</span>
-                            <span class="tech-badge">Trust Providers</span>
-                        </div>
-
-                        <div class="project-links">
-                            <a href="https://github.com/imran-siddique/agentmesh-integrations" target="_blank" rel="noopener noreferrer" class="btn-primary">
+                            <a href="https://github.com/agentrust-io/awesome-ai-governance" target="_blank" rel="noopener noreferrer" class="btn-primary">
                                 View on GitHub →
                             </a>
                         </div>
@@ -417,47 +331,9 @@
                 </div>
 
                 <div class="ecosystem-section" style="margin-top: 4rem;">
-                    <h2>🌍 Ecosystem Integrations</h2>
-                    <p class="lead" style="margin-bottom: 1.5rem;">Our governance layer is integrated into major AI frameworks, with 19 integrations across LangChain, CrewAI, AutoGen, Google ADK, OpenAI Agents, LlamaIndex, Haystack, Mastra, MCP, A2A, and more.</p>
-                    
-                    <h3 style="margin-top: 1.5rem;">✅ Merged Contributions</h3>
-                    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; margin-top: 1rem;">
-                        <div style="padding: 1.5rem; border-radius: 12px; background: var(--bg-secondary); border: 1px solid var(--border-color);">
-                            <h4 style="margin-bottom: 0.5rem;">🟢 Dify (65K ⭐)</h4>
-                            <p>AgentMesh Trust Layer plugin merged into the Dify Marketplace. Real-time trust scoring for Dify agent workflows.</p>
-                            <a href="https://github.com/langgenius/dify-plugins/pull/2060" target="_blank" rel="noopener noreferrer" style="color: var(--accent-primary);">PR #2060 →</a>
-                        </div>
-                        <div style="padding: 1.5rem; border-radius: 12px; background: var(--bg-secondary); border: 1px solid var(--border-color);">
-                            <h4 style="margin-bottom: 0.5rem;">🟢 LlamaIndex (47K ⭐)</h4>
-                            <p>AgentMesh Trust Layer integration for LlamaIndex agent pipelines. Trust-verified tool calls and query routing.</p>
-                            <a href="https://github.com/run-llama/llama_index/pull/20644" target="_blank" rel="noopener noreferrer" style="color: var(--accent-primary);">PR #20644 →</a>
-                        </div>
-                        <div style="padding: 1.5rem; border-radius: 12px; background: var(--bg-secondary); border: 1px solid var(--border-color);">
-                            <h4 style="margin-bottom: 0.5rem;">🟢 Microsoft Agent-Lightning (15K ⭐)</h4>
-                            <p>Agent-OS governance integration for reinforcement learning training pipelines.</p>
-                            <a href="https://github.com/microsoft/agent-lightning/pull/478" target="_blank" rel="noopener noreferrer" style="color: var(--accent-primary);">PR #478 →</a>
-                        </div>
-                    </div>
-
-                    <h3 style="margin-top: 2rem;">🔄 Open Proposals (10 Frameworks)</h3>
-                    <p style="margin-bottom: 1rem;">Governance integration proposals filed across major frameworks:</p>
-                    <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 1.5rem;">
-                        <span class="tech-badge">CrewAI (44K ⭐)</span>
-                        <span class="tech-badge">AutoGen (54K ⭐)</span>
-                        <span class="tech-badge">LangGraph (24K ⭐)</span>
-                        <span class="tech-badge">Google ADK (18K ⭐)</span>
-                        <span class="tech-badge">Semantic Kernel (27K ⭐)</span>
-                        <span class="tech-badge">smolagents (25K ⭐)</span>
-                        <span class="tech-badge">PydanticAI (15K ⭐)</span>
-                        <span class="tech-badge">OpenAI Swarm (21K ⭐)</span>
-                        <span class="tech-badge">AGENT.md Spec</span>
-                        <span class="tech-badge">Oracle Agent Spec</span>
-                    </div>
-                </div>
-
-                <div class="research-section" style="margin-top: 4rem;">
-                    <h2>📄 Research Papers</h2>
-                    <p class="lead" style="margin-bottom: 1.5rem;">Research papers spanning agent governance, trust protocols, and reliability engineering. See the GitHub repositories for details.</p>
+                    <h2>🌍 Ecosystem</h2>
+                    <p class="lead" style="margin-bottom: 1rem;">The Agent Governance Toolkit ships governed examples and adapters for around ten agent frameworks, including LangChain, CrewAI, AutoGen, Google ADK, OpenAI Agents, LlamaIndex, and smolagents, alongside MCP and A2A. See the toolkit repository for the current, authoritative list.</p>
+                    <a href="https://github.com/microsoft/agent-governance-toolkit" target="_blank" rel="noopener noreferrer" style="color: var(--accent-primary);">Framework integrations on GitHub →</a>
                 </div>
 
                 <div class="github-cta">
@@ -520,7 +396,7 @@
             </div>
             <div class="footer-bottom">
                 <p>&copy; 2026 Imran Siddique. All rights reserved.</p>
-                <p>Last updated: May 2026</p>
+                <p>Last updated: July 2026</p>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
## Why this is a new PR
PR #14 squash-merged while it still held only the role-rename commits. The re-center commit was pushed to that branch afterward, so it never reached `main`. This PR lands the re-center content.

## What
Re-centers the site and corrects every factual claim to a verified public value (GitHub/PyPI/opaque.co, July 2026).

- Headline: **Chief Platform Officer at Opaque Systems** (role + one-line only).
- Current-work focus: agentrust-io open standards **TRACE, cMCP, Agent Manifest, cA2A**.
- **Agent Governance Toolkit** as flagship (`microsoft/agent-governance-toolkit`, **4,877★**, MIT, **992 conformance tests**, 5 distributions, ~10 integrations, 10/10 OWASP).
- Agent OS / AgentMesh / Agent SRE demoted to prior work (repos are deprecated, consolidated into AGT).
- Removed: "13,000+ tests", "8 packages", "19 integrations", the **"0% vs 26.67%" benchmark** (in no repo), unverified merged-PR claims and framework star counts, agent-lightning "15K".
- Experience → 18 years at Microsoft; "20+ patents" → the patents actually listed.
- `llms.txt` and JSON-LD updated to match.

Files: `index.html`, `about.html`, `projects.html`, `llms.txt`.

## Still open for your call
- `agent-mesh-docs/` sub-page + "AgentMesh" nav tab (AgentMesh is now prior work).
- Footer "Projects" links site-wide still point to deprecated repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)